### PR TITLE
Fix crash when options parameter is undefined

### DIFF
--- a/lib/alerts.js
+++ b/lib/alerts.js
@@ -5,6 +5,9 @@ var config = require('../config');
 process.env.TZ = 'Asia/Jerusalem'
 
 module.exports = function (callback, options) {
+    // Ensure options is an object
+    options = options || {};
+    
     // Execute HTTP request to HFC API and get current alert as a JS object
     getHFCAlertsJSON(options, function (err, json) {
         // JSON retrieval failed?


### PR DESCRIPTION
Fix TypeError when getActiveAlert() is called with only a callback parameter by ensuring options is always defined.